### PR TITLE
[Fix] Repo URL in the `/start` command

### DIFF
--- a/dictionary.py
+++ b/dictionary.py
@@ -23,7 +23,7 @@ alienEmojiDictionary = {
 }
 
 messageDictionary = {
-    "start": "Pancake Bot is a chatbot designed to bring some fun into your conversations. It offers a variety of playful features, from emojis to simulating drinks. Explore and enjoy! For assistance or more info, type /help.\n link to the repository : https://github.com/dwesh163/FSD-Bot/",
+    "start": "Pancake Bot is a chatbot designed to bring some fun into your conversations. It offers a variety of playful features, from emojis to simulating drinks. Explore and enjoy! For assistance or more info, type /help.\n link to the repository : https://github.com/dwesh163/Pancake-Bot/",
     "help" : "List of commands /brain or /smart: The bot responds with a random number of brain emojis 🧠.\n/code or /geek: The bot responds with a random number of computer emojis 💻.\n/alien or /ufo : The bot responds with a random number of alien emojis 👾. \n/drink or /coffee or /beer or /drink something : The bot responds with messages to simulate the consumption of drinks.\n/start : This command briefly explains the bot's functionalities.\n /help : This command provides a summary explanation of the bot's functionalities."
 }
 


### PR DESCRIPTION
The `/start` command was still displaying the old (https://github.com/dwesh163/FSD-Bot/) URL of the repository instead of the current one (https://github.com/dwesh163/Pancake-Bot/).